### PR TITLE
rake tasks and some refacto on the indeed api jobs

### DIFF
--- a/app/jobs/indeed_get_jobs_job.rb
+++ b/app/jobs/indeed_get_jobs_job.rb
@@ -1,11 +1,11 @@
 class IndeedGetJobsJob < ApplicationJob
   queue_as :default
 
-  def perform
+  def perform(limit_query = nil)
     indeed = IndeedApi.new(
       publisher_key: ENV["indeed_publisher_key"],
       categories: Category.all.to_a,
-      limit: 10
+      limit: limit_query || 10
     )
     joboffers = indeed.get_jobs
     puts "===> Number of job offers loaded from Indeed API: #{joboffers ? joboffers.count : 0}"

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -9,6 +9,7 @@ class JobOffer < ApplicationRecord
   validates_associated :company, :category
   validates :jobkey, uniqueness: true
 
+  # default_scope { where(expired: ) }
   scope :current, -> { where(expired: false) }
   scope :expired, -> { where(expired: true) }
 

--- a/app/services/indeed_api.rb
+++ b/app/services/indeed_api.rb
@@ -101,15 +101,16 @@ class IndeedApi
       offer_serialized = open(url).read
       offer = JSON.parse(offer_serialized)
       fail unless offer['results']
+      return job_offer_attributes if offer['results'].empty?
       p "updating job_offer #{job_offer_attributes[:jobkey]}"
-      job_offer_attributes[:description_additional] = offer['results'].first['snippet']
-      job_offer_attributes[:url_source_original] = offer['results'].first['url']
-      job_offer_attributes[:expired] = offer['results'].first['expired']
     rescue => e
       puts "***** An error occurred call_api with message #{e.message}: retrying in 5 seconds - jobkey: #{job_offer_attributes[:jobkey]}*****"
       sleep 2
       retry
     end
+    job_offer_attributes[:description_additional] = offer['results'].first['snippet']
+    job_offer_attributes[:url_source_original] = offer['results'].first['url']
+    job_offer_attributes[:expired] = offer['results'].first['expired']
     job_offer_attributes
   end
 

--- a/lib/tasks/indeed_api.rake
+++ b/lib/tasks/indeed_api.rake
@@ -1,0 +1,15 @@
+namespace :indeed_api do
+  desc "Get X jobs offers from Indeed API for each categories"
+  task :get_jobs, [:limit] => :environment do |t, args|
+    puts "Enqueuing Indeed jobs offers load process"
+    limit = args[:limit].to_i
+    IndeedGetJobsJob.perform_later(limit)
+  end
+
+  desc "Check if current jobs are expired on Indeed Api"
+  task check_jobs_expiry: :environment do
+    puts "Enqueuing Indeed jobs offers expiry check process"
+    IndeedApiJobsUpdateJob.perform_later
+  end
+
+end


### PR DESCRIPTION
We can now trigger these jobs via Rake (and then use Heroku Scheduler to trigger them).
fix #18 